### PR TITLE
Permit showing files as AppleDouble

### DIFF
--- a/fusefs_hfs.h
+++ b/fusefs_hfs.h
@@ -13,4 +13,5 @@ struct fusehfs_options {
     char	*encoding;
 	char	*mountpoint;
 	int		readonly;
+  int appledouble;
 };

--- a/main.c
+++ b/main.c
@@ -67,7 +67,8 @@ extern struct fuse_operations FuseHFS_operations;
 struct fusehfs_options options = {
     .path =         NULL,
     .encoding =		NULL,
-	.readonly =		0
+    .readonly =		0
+    .appledouble = 0,
 };
 
 enum {
@@ -75,6 +76,7 @@ enum {
 	KEY_HELP,
 	KEY_ENCODING,
 	KEY_READONLY,
+	KEY_APPLEDOUBLE,
 };
 
 static struct fuse_opt FuseHFS_opts[] = {
@@ -84,6 +86,7 @@ static struct fuse_opt FuseHFS_opts[] = {
 	FUSE_OPT_KEY("--help",		KEY_HELP),
 	FUSE_OPT_KEY("--encoding=",	KEY_ENCODING),
 	FUSE_OPT_KEY("--readonly",	KEY_READONLY),
+	FUSE_OPT_KEY("--appledouble",	KEY_APPLEDOUBLE),
 	FUSE_OPT_END
 };
 
@@ -122,6 +125,9 @@ static int FuseHFS_opt_proc(void *data, const char *arg, int key, struct fuse_ar
 			exit(0);
 		case KEY_READONLY:
 			options.readonly = 1;
+			return 0;
+	        case KEY_APPLEDOUBLE:
+			options.appledouble = 1;
 			return 0;
 	}
 	return 0;


### PR DESCRIPTION
This allows resource forks and finder info to be accessed on OSes that are not aware of them.

This is similar to what OSX uses on FAT32, so many apps that need resource forks are likely aware of them